### PR TITLE
update template to use key vault reference

### DIFF
--- a/Resources/ArmTemplates/parameters.json
+++ b/Resources/ArmTemplates/parameters.json
@@ -19,6 +19,9 @@
         },
         "functionAppName": {
             "value": "__FunctionAppName__"
-        }
+        },
+        "keyVaultName": {
+            "value": "__sharedKeyVaultName__"
+        }    
     }
 }

--- a/Resources/ArmTemplates/template.json
+++ b/Resources/ArmTemplates/template.json
@@ -16,6 +16,9 @@
     },
     "functionAppName": {
       "type": "string"
+    },
+    "keyVaultName": {
+      "type": "string"
     }
   },
   "variables": {
@@ -31,13 +34,13 @@
         "FUNCTIONS_EXTENSION_VERSION": "~4",
         "MSDEPLOY_RENAME_LOCKED_FILES": "1",
         "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(resourceId(variables('sharedAppInsightsResourceGroup'), 'Microsoft.Insights/components', variables('sharedAppInsightsName')), '2014-04-01').InstrumentationKey]",
-        "AzureWebJobsStorage": "[concat('DefaultEndpointsProtocol=https;AccountName=',parameters('appSharedStorageAccountName'),';AccountKey=',listKeys(resourceId(parameters('appSharedResourceGroup'), 'Microsoft.Storage/storageAccounts', parameters('appSharedStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value, ';EndpointSuffix=core.windows.net')]",
+        "AzureWebJobsStorage": "[format('@Microsoft.KeyVault(VaultName={0};SecretName=FAMStorageConnectionString)', parameters('keyVaultName'))]",
         "WEBSITE_RUN_FROM_PACKAGE": "1",
         "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
         "DocumentStoreID": "dfc-prime-contractor-areas-db",
         "LocalAuthorityCollectionID": "LocalAuthorities",
         "DocumentStoreEndpointAddress": "[concat('https://',parameters('cosmosDbAccountName'),'.documents.azure.com:443/')]",
-        "DocumentStoreAccountKey": "[listKeys(resourceId(parameters('appSharedResourceGroup'), 'Microsoft.DocumentDB/databaseAccounts', parameters('cosmosDbAccountName')), providers('Microsoft.DocumentDB', 'databaseAccounts').apiVersions[0]).primaryMasterKey]"
+        "DocumentStoreAccountKey": "[format('@Microsoft.KeyVault(VaultName={0};SecretName=FAMCosmosConnectionString)', parameters('keyVaultName'))]"
       }
     },
     {

--- a/Resources/ArmTemplates/test-parameters.json
+++ b/Resources/ArmTemplates/test-parameters.json
@@ -16,6 +16,9 @@
         },
         "functionAppName": {
             "value": "dfc-foo-fam-la-fa-ver2"
+        },
+        "keyVaultName": {
+            "value": "dfc-dev-shared-kv"
         }
     }
 }

--- a/Resources/AzureDevOps/VariableTemplates/DevEnvironmentVariables.yml
+++ b/Resources/AzureDevOps/VariableTemplates/DevEnvironmentVariables.yml
@@ -3,3 +3,5 @@ variables:
   value: DEV
 - name: FunctionAppName
   value: dfc-dev-fam-la-fa
+- name: sharedKeyVaultName
+  value: dfc-dev-shared-kv

--- a/Resources/AzureDevOps/VariableTemplates/LabEnvironmentVariables.yml
+++ b/Resources/AzureDevOps/VariableTemplates/LabEnvironmentVariables.yml
@@ -3,3 +3,5 @@ variables:
   value: LAB
 - name: FunctionAppName
   value: dfc-lab-fam-la-fa
+- name: sharedKeyVaultName
+  value: dfc-lab-shared-kv

--- a/Resources/AzureDevOps/VariableTemplates/PPEnvironmentVariables.yml
+++ b/Resources/AzureDevOps/VariableTemplates/PPEnvironmentVariables.yml
@@ -3,3 +3,5 @@ variables:
   value: PP
 - name: FunctionAppName
   value: dfc-pp-fam-la-fa-ver2
+- name: sharedKeyVaultName
+  value: dfc-pp-shared-kv

--- a/Resources/AzureDevOps/VariableTemplates/PRDEnvironmentVariables.yml
+++ b/Resources/AzureDevOps/VariableTemplates/PRDEnvironmentVariables.yml
@@ -3,3 +3,5 @@ variables:
   value: PRD
 - name: FunctionAppName
   value: dfc-prd-fam-la-fa-ver2
+- name: sharedKeyVaultName
+  value: dfc-prd-shared-kv

--- a/Resources/AzureDevOps/VariableTemplates/SitEnvironmentVariables.yml
+++ b/Resources/AzureDevOps/VariableTemplates/SitEnvironmentVariables.yml
@@ -3,3 +3,5 @@ variables:
   value: SIT
 - name: FunctionAppName
   value: dfc-sit-fam-la-fa
+- name: sharedKeyVaultName
+  value: dfc-sit-shared-kv


### PR DESCRIPTION
Changes Made:

Replaced listKeys() usage for:
AzureWebJobsStorage
DocumentStoreAccountKey
Added Key Vault references for the above.
Added keyVaultName as a new ARM template parameter.
Updated parameters.json to include tokenised keyVaultName.
Updated test-parameters.json to include hardcoded keyVaultName.
Updated all environment variable templates with the key vault name.